### PR TITLE
Update engine node criteria to include >= 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/gajus/count-lines-in-file"
   },
   "engines": {
-    "node": "^5"
+    "node": ">= 5.0.0"
   },
   "keywords": [
     "wc",


### PR DESCRIPTION
Currently fails on yarn install since I am on 6.7.0 and the node criteria does not match.